### PR TITLE
ignore file temporarily generated by codedoc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Codedoc build temporary file
+.codedoc/__tmp_*


### PR DESCRIPTION
Fixes #6 

I didn't think this change matched the description for any of the existing sections in the ignore file, so created a new one...including a description.  Maybe a better location or description exists though.