### PR TITLE
added links from the README to CODEDOC and the coding.blog Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [`coding.blog`](https://coding.blog) boilerplate
 
-Starter project for [`coding.blog`](https://coding.blog) blogs.
+Starter project for [`coding.blog`](https://coding.blog) blogs that uses [CODEDOC](https://codedoc.cc/) and the [`coding.blog` Plugin](https://connect-platform.github.io/coding-blog-plugin/).
 
 ## Prerequisites
 


### PR DESCRIPTION
Quoting https://github.com/CONNECT-platform/coding-blog-plugin/issues/18#issuecomment-676786791
> Can I suggest that you add this to the README of the [boilerplate project](https://github.com/CONNECT-platform/coding-blog-boilerplate)? It wasn't obvious to me to look at the documentation of `coding-blog-plugin`, because the process of setting up a blog using the boilerplate means you don't ever really interact with `coding-blog-plugin`.

This PR adds links to `CODEDOC` and the `coding.blog Plugin`.